### PR TITLE
No code is treated as STOP

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -201,6 +201,8 @@ func (in *EVMInterpreter) run(state *InterpreterState, maxSteps uint64) (ret []b
 
 	// Don't bother with the execution if there's no code.
 	if len(contract.Code) == 0 {
+		// no code is treated as STOP
+		state.Error = errStopToken
 		return nil, nil
 	}
 


### PR DESCRIPTION
The CT produced a state with no code which has not been handled correctly by geth. No code should be handled like a STOP instruction.