### PR TITLE
Move closing of wallets to background worker to eliminate data race

### DIFF
--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -93,9 +93,6 @@ func NewManager(config *Config, backends ...Backend) *Manager {
 
 // Close terminates the account manager's internal notification processes.
 func (am *Manager) Close() error {
-	for _, w := range am.wallets {
-		w.Close()
-	}
 	errc := make(chan error)
 	am.quit <- errc
 	return <-errc
@@ -149,6 +146,10 @@ func (am *Manager) update() {
 			am.lock.Unlock()
 			close(event.processed)
 		case errc := <-am.quit:
+			// Close all wallets
+			for _, w := range am.wallets {
+				w.Close()
+			}
 			// Manager terminating, return
 			errc <- nil
 			// Signals event emitters the loop is not receiving values


### PR DESCRIPTION
There is a data race between the closing of the manager and the background thread handling operations on the managers state. This update resolves this issue.
