### PR TITLE
Add max gas parameter to evm config

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -406,8 +406,10 @@ func (st *stateTransition) preCheck() error {
 		}
 	}
 	// Verify tx gas limit does not exceed EIP-7825 cap.
-	if isOsaka && msg.GasLimit > st.evm.Config.MaxTxGas {
-		return fmt.Errorf("%w (cap: %d, tx: %d)", ErrGasLimitTooHigh, params.MaxTxGas, msg.GasLimit)
+	if msg.From != (common.Address{}) {
+		if isOsaka && msg.GasLimit > st.evm.Config.MaxTxGas {
+			return fmt.Errorf("%w (cap: %d, tx: %d)", ErrGasLimitTooHigh, params.MaxTxGas, msg.GasLimit)
+		}
 	}
 	return st.buyGas()
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -406,7 +406,7 @@ func (st *stateTransition) preCheck() error {
 		}
 	}
 	// Verify tx gas limit does not exceed EIP-7825 cap.
-	if isOsaka && msg.GasLimit > params.MaxTxGas {
+	if isOsaka && msg.GasLimit > st.evm.Config.MaxTxGas {
 		return fmt.Errorf("%w (cap: %d, tx: %d)", ErrGasLimitTooHigh, params.MaxTxGas, msg.GasLimit)
 	}
 	return st.buyGas()
@@ -432,6 +432,11 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 	// 4. the purchased gas is enough to cover intrinsic usage
 	// 5. there is no overflow when calculating intrinsic gas
 	// 6. caller has enough balance to cover asset transfer for **topmost** call
+
+	// if no max gas has been set, then use constant from EIP-7825
+	if st.evm.Config.MaxTxGas == 0 {
+		st.evm.Config.MaxTxGas = params.MaxTxGas
+	}
 
 	// Check clauses 1-3, buy gas if everything is correct
 	if err := st.preCheck(); err != nil {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -405,8 +405,12 @@ func (st *stateTransition) preCheck() error {
 			return fmt.Errorf("%w (sender %v)", ErrEmptyAuthList, msg.From)
 		}
 	}
-	// Verify tx gas limit does not exceed EIP-7825 cap.
+
+	// This is a Sonic specific check. Transactions coming from account zero are
+	// special transactions that do not need to adhere to the gas limit cap
+	// introduced in Osaka (EIP-7825).
 	if msg.From != (common.Address{}) {
+		// Verify tx gas limit does not exceed EIP-7825 cap.
 		if isOsaka && msg.GasLimit > st.evm.Config.MaxTxGas {
 			return fmt.Errorf("%w (cap: %d, tx: %d)", ErrGasLimitTooHigh, params.MaxTxGas, msg.GasLimit)
 		}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -440,7 +440,8 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 	// 6. caller has enough balance to cover asset transfer for **topmost** call
 
 	// if no max gas has been set, then use constant from EIP-7825
-	if st.evm.Config.MaxTxGas == 0 {
+	if st.evm.ChainConfig().IsOsaka(st.evm.Context.BlockNumber, st.evm.Context.Time) &&
+		st.evm.Config.MaxTxGas == 0 {
 		st.evm.Config.MaxTxGas = params.MaxTxGas
 	}
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -439,12 +439,6 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 	// 5. there is no overflow when calculating intrinsic gas
 	// 6. caller has enough balance to cover asset transfer for **topmost** call
 
-	// if no max gas has been set, then use constant from EIP-7825
-	if st.evm.ChainConfig().IsOsaka(st.evm.Context.BlockNumber, st.evm.Context.Time) &&
-		st.evm.Config.MaxTxGas == 0 {
-		st.evm.Config.MaxTxGas = params.MaxTxGas
-	}
-
 	// Check clauses 1-3, buy gas if everything is correct
 	if err := st.preCheck(); err != nil {
 		return nil, err

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -45,10 +45,11 @@ type Config struct {
 	// By setting the following flags to their default values, the EVM will behave as the vanilla Ethereum EVM.
 	// To get the Fantom-main-net behavior, all of the following flags need to be enabled. Future networks may
 	// have different configurations.
-	ChargeExcessGas                 bool // if enabled, 10% of excessive gas is charged for the execution
-	IgnoreGasFeeCap                 bool // if enabled, gas fee cap is ignored
-	InsufficientBalanceIsNotAnError bool // if enabled, insufficient balance is treated as a revert, not an execution error on the top level
-	SkipTipPaymentToCoinbase        bool // if enabled, tip payment is not made to the coinbase address
+	ChargeExcessGas                 bool   // if enabled, 10% of excessive gas is charged for the execution
+	IgnoreGasFeeCap                 bool   // if enabled, gas fee cap is ignored
+	InsufficientBalanceIsNotAnError bool   // if enabled, insufficient balance is treated as a revert, not an execution error on the top level
+	SkipTipPaymentToCoinbase        bool   // if enabled, tip payment is not made to the coinbase address
+	MaxTxGas                        uint64 // maximum gas allowed per transaction.
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,


### PR DESCRIPTION
This PR is part of https://github.com/0xsoniclabs/sonic-admin/issues/364

This PR adds the `MaxTxGas` to the evm config struct so that the max gas can be parametrized. Unlike the original [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825), in Sonic, `MaxTxGas` shall be a network rule parameter. 
This PR also adds an exception to ignore the transaction limit for internal transactions.