### PR TITLE
Remove internal transactions special case for Osaka

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -406,14 +406,9 @@ func (st *stateTransition) preCheck() error {
 		}
 	}
 
-	// This is a Sonic specific check. Transactions coming from account zero are
-	// special transactions that do not need to adhere to the gas limit cap
-	// introduced in Osaka (EIP-7825).
-	if msg.From != (common.Address{}) {
-		// Verify tx gas limit does not exceed EIP-7825 cap.
-		if isOsaka && msg.GasLimit > st.evm.Config.MaxTxGas {
-			return fmt.Errorf("%w (cap: %d, tx: %d)", ErrGasLimitTooHigh, params.MaxTxGas, msg.GasLimit)
-		}
+	// Verify tx gas limit does not exceed EIP-7825 cap.
+	if isOsaka && msg.GasLimit > st.evm.Config.MaxTxGas {
+		return fmt.Errorf("%w (cap: %d, tx: %d)", ErrGasLimitTooHigh, st.evm.Config.MaxTxGas, msg.GasLimit)
 	}
 	return st.buyGas()
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -406,9 +406,15 @@ func (st *stateTransition) preCheck() error {
 		}
 	}
 
+	maxTxGas := params.MaxTxGas
+	// This is a Sonic specific modification. If config.MaxTxGas is set, use it instead of
+	// the default params.MaxTxGas.
+	if st.evm.Config.OverrideMaxTxGas {
+		maxTxGas = st.evm.Config.MaxTxGas
+	}
 	// Verify tx gas limit does not exceed EIP-7825 cap.
-	if isOsaka && msg.GasLimit > st.evm.Config.MaxTxGas {
-		return fmt.Errorf("%w (cap: %d, tx: %d)", ErrGasLimitTooHigh, st.evm.Config.MaxTxGas, msg.GasLimit)
+	if isOsaka && msg.GasLimit > maxTxGas {
+		return fmt.Errorf("%w (cap: %d, tx: %d)", ErrGasLimitTooHigh, maxTxGas, msg.GasLimit)
 	}
 	return st.buyGas()
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -409,8 +409,8 @@ func (st *stateTransition) preCheck() error {
 	maxTxGas := params.MaxTxGas
 	// This is a Sonic specific modification. If config.MaxTxGas is set, use it instead of
 	// the default params.MaxTxGas.
-	if st.evm.Config.OverrideMaxTxGas {
-		maxTxGas = st.evm.Config.MaxTxGas
+	if st.evm.Config.MaxTxGas != nil {
+		maxTxGas = *st.evm.Config.MaxTxGas
 	}
 	// Verify tx gas limit does not exceed EIP-7825 cap.
 	if isOsaka && msg.GasLimit > maxTxGas {

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -50,7 +50,9 @@ type Config struct {
 	InsufficientBalanceIsNotAnError bool // if enabled, insufficient balance is treated as a revert, not an execution error on the top level
 	SkipTipPaymentToCoinbase        bool // if enabled, tip payment is not made to the coinbase address
 
-	MaxTxGas *uint64 // maximum gas allowed per transaction.
+	// maximum gas allowed per transaction.
+	// If nil, this is interpreted as "not set" and the default params value is used.
+	MaxTxGas *uint64
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -45,11 +45,13 @@ type Config struct {
 	// By setting the following flags to their default values, the EVM will behave as the vanilla Ethereum EVM.
 	// To get the Fantom-main-net behavior, all of the following flags need to be enabled. Future networks may
 	// have different configurations.
-	ChargeExcessGas                 bool   // if enabled, 10% of excessive gas is charged for the execution
-	IgnoreGasFeeCap                 bool   // if enabled, gas fee cap is ignored
-	InsufficientBalanceIsNotAnError bool   // if enabled, insufficient balance is treated as a revert, not an execution error on the top level
-	SkipTipPaymentToCoinbase        bool   // if enabled, tip payment is not made to the coinbase address
-	MaxTxGas                        uint64 // maximum gas allowed per transaction.
+	ChargeExcessGas                 bool // if enabled, 10% of excessive gas is charged for the execution
+	IgnoreGasFeeCap                 bool // if enabled, gas fee cap is ignored
+	InsufficientBalanceIsNotAnError bool // if enabled, insufficient balance is treated as a revert, not an execution error on the top level
+	SkipTipPaymentToCoinbase        bool // if enabled, tip payment is not made to the coinbase address
+
+	OverrideMaxTxGas bool   // if enabled, MaxTxGas is used instead of the block gas limit to cap tx gas usage
+	MaxTxGas         uint64 // maximum gas allowed per transaction.
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -50,7 +50,7 @@ type Config struct {
 	InsufficientBalanceIsNotAnError bool // if enabled, insufficient balance is treated as a revert, not an execution error on the top level
 	SkipTipPaymentToCoinbase        bool // if enabled, tip payment is not made to the coinbase address
 
-	// maximum gas allowed per transaction.
+	// MaxTxGas is the maximum gas allowed per transaction.
 	// If nil, this is interpreted as "not set" and the default params value is used.
 	MaxTxGas *uint64
 }

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -50,8 +50,7 @@ type Config struct {
 	InsufficientBalanceIsNotAnError bool // if enabled, insufficient balance is treated as a revert, not an execution error on the top level
 	SkipTipPaymentToCoinbase        bool // if enabled, tip payment is not made to the coinbase address
 
-	OverrideMaxTxGas bool   // if enabled, MaxTxGas is used instead of the block gas limit to cap tx gas usage
-	MaxTxGas         uint64 // maximum gas allowed per transaction.
+	MaxTxGas *uint64 // maximum gas allowed per transaction.
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,


### PR DESCRIPTION
This PR removes the special handling of internal transactions for the max gas Osaka check. The processor should not handle special cases with internal knowledge of what internal transactions are or not. Instead it should just look at the config options given to it act according to those. 

To follow this idea, this PR introduces a boolean flag `OverrideMaxTxGas` which will tell the processor if it should use the given parameter (`MaxTxGas`) or use the default EIP value. This also means the changes required to enable this functionality are minimal, since using always `MaxTxGas` would imply adapting many tests (unrelated to Osaka). 