### PR TITLE
Change module path from ethereum to 0xsoniclabs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ethereum/go-ethereum
+module github.com/0xsoniclabs/go-ethereum
 
 go 1.21
 


### PR DESCRIPTION
To allow projects to import both original `go-ethereum` and soniclabs' `go-ethereum` without having a collision.