### PR TITLE
Core: Add custom contract and init code size limits

### DIFF
--- a/core/sonic_changes_test.go
+++ b/core/sonic_changes_test.go
@@ -1,0 +1,92 @@
+package core
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+func TestCustomCodeSize_MaxInitCodeSizeIsEnforcedWhenSet(t *testing.T) {
+	asPointer := func(v int) *int {
+		return &v
+	}
+
+	customLimit := 100_000
+	tests := map[string]struct {
+		maxInitCodeSize *int
+		initCodeSize    uint64
+		expectedError   error
+	}{
+		"default initCodeSize limit": {
+			initCodeSize: params.MaxInitCodeSize,
+		},
+		"default initCodeSize above limit": {
+			initCodeSize:  params.MaxInitCodeSize + 1,
+			expectedError: ErrMaxInitCodeSizeExceeded,
+		},
+		"custom initCodeSize limit": {
+			maxInitCodeSize: asPointer(customLimit),
+			initCodeSize:    uint64(customLimit),
+		},
+		"custom initCodeSize above limit": {
+			maxInitCodeSize: asPointer(customLimit),
+			initCodeSize:    uint64(customLimit + 1),
+			expectedError:   ErrMaxInitCodeSizeExceeded,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			stateDB, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+			if err != nil {
+				t.Fatalf("failed to create stateDB: %v", err)
+			}
+
+			chainConfig := &params.ChainConfig{
+				LondonBlock:  big.NewInt(0),
+				ShanghaiTime: new(uint64),
+			}
+			blockContext := vm.BlockContext{
+				CanTransfer: func(vm.StateDB, common.Address, *uint256.Int) bool { return true },
+				Transfer:    func(vm.StateDB, common.Address, common.Address, *uint256.Int) {},
+				BlockNumber: big.NewInt(10),
+				BaseFee:     big.NewInt(0),
+				Random:      &common.Hash{0x42},
+			}
+			config := vm.Config{
+				MaxInitCodeSize:                 test.maxInitCodeSize,
+				IgnoreGasFeeCap:                 true,
+				InsufficientBalanceIsNotAnError: true,
+			}
+			evm := vm.NewEVM(blockContext, stateDB, chainConfig, config)
+
+			message := &Message{
+				GasLimit:              1_000_000,
+				GasPrice:              big.NewInt(0),
+				GasFeeCap:             big.NewInt(0),
+				GasTipCap:             big.NewInt(0),
+				Data:                  make([]byte, test.initCodeSize),
+				To:                    nil, // contract creation
+				SkipNonceChecks:       true,
+				SkipTransactionChecks: true,
+			}
+
+			gasPool := new(GasPool)
+			gasPool.AddGas(1_000_000)
+
+			stateTransition := newStateTransition(evm, message, gasPool)
+
+			_, err = stateTransition.execute()
+			if !errors.Is(err, test.expectedError) {
+				t.Errorf("unexpected error: got %v, want %v", err, test.expectedError)
+			}
+		})
+	}
+}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -502,8 +502,10 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 	}
 
 	// Check whether the init code size has been exceeded.
-	if rules.IsShanghai && contractCreation && len(msg.Data) > params.MaxInitCodeSize {
+	if st.evm.Config.MaxInitCodeSize == nil && rules.IsShanghai && contractCreation && len(msg.Data) > params.MaxInitCodeSize {
 		return nil, fmt.Errorf("%w: code size %v limit %v", ErrMaxInitCodeSizeExceeded, len(msg.Data), params.MaxInitCodeSize)
+	} else if st.evm.Config.MaxInitCodeSize != nil && contractCreation && len(msg.Data) > *st.evm.Config.MaxInitCodeSize {
+		return nil, fmt.Errorf("%w: code size %v limit %v", ErrMaxInitCodeSizeExceeded, len(msg.Data), *st.evm.Config.MaxCodeSize)
 	}
 
 	// Execute the preparatory steps for state transition which includes:

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -502,10 +502,14 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 	}
 
 	// Check whether the init code size has been exceeded.
-	if st.evm.Config.MaxInitCodeSize == nil && rules.IsShanghai && contractCreation && len(msg.Data) > params.MaxInitCodeSize {
-		return nil, fmt.Errorf("%w: code size %v limit %v", ErrMaxInitCodeSizeExceeded, len(msg.Data), params.MaxInitCodeSize)
-	} else if st.evm.Config.MaxInitCodeSize != nil && contractCreation && len(msg.Data) > *st.evm.Config.MaxInitCodeSize {
-		return nil, fmt.Errorf("%w: code size %v limit %v", ErrMaxInitCodeSizeExceeded, len(msg.Data), *st.evm.Config.MaxCodeSize)
+	if st.evm.Config.MaxInitCodeSize == nil && rules.IsShanghai &&
+		contractCreation && len(msg.Data) > params.MaxInitCodeSize {
+		return nil, fmt.Errorf("%w: code size %v limit %v",
+			ErrMaxInitCodeSizeExceeded, len(msg.Data), params.MaxInitCodeSize)
+	} else if st.evm.Config.MaxInitCodeSize != nil && rules.IsShanghai &&
+		contractCreation && len(msg.Data) > *st.evm.Config.MaxInitCodeSize {
+		return nil, fmt.Errorf("%w: code size %v limit %v",
+			ErrMaxInitCodeSizeExceeded, len(msg.Data), *st.evm.Config.MaxInitCodeSize)
 	}
 
 	// Execute the preparatory steps for state transition which includes:

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -605,7 +605,9 @@ func (evm *EVM) initNewContract(contract *Contract, address common.Address) ([]b
 	}
 
 	// Check whether the max code size has been exceeded, assign err if the case.
-	if evm.chainRules.IsEIP158 && len(ret) > params.MaxCodeSize {
+	if evm.Config.MaxCodeSize == nil && evm.chainRules.IsEIP158 && len(ret) > params.MaxCodeSize {
+		return ret, ErrMaxCodeSizeExceeded
+	} else if evm.Config.MaxCodeSize != nil && len(ret) > *evm.Config.MaxCodeSize {
 		return ret, ErrMaxCodeSizeExceeded
 	}
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -607,7 +607,7 @@ func (evm *EVM) initNewContract(contract *Contract, address common.Address) ([]b
 	// Check whether the max code size has been exceeded, assign err if the case.
 	if evm.Config.MaxCodeSize == nil && evm.chainRules.IsEIP158 && len(ret) > params.MaxCodeSize {
 		return ret, ErrMaxCodeSizeExceeded
-	} else if evm.Config.MaxCodeSize != nil && len(ret) > *evm.Config.MaxCodeSize {
+	} else if evm.Config.MaxCodeSize != nil && evm.chainRules.IsEIP158 && len(ret) > *evm.Config.MaxCodeSize {
 		return ret, ErrMaxCodeSizeExceeded
 	}
 

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -312,9 +312,12 @@ func gasCreateEip3860(evm *EVM, contract *Contract, stack *Stack, mem *Memory, m
 	if overflow {
 		return 0, ErrGasUintOverflow
 	}
-	if size > params.MaxInitCodeSize {
+	if evm.Config.MaxInitCodeSize == nil && size > params.MaxInitCodeSize {
+		return 0, fmt.Errorf("%w: size %d", ErrMaxInitCodeSizeExceeded, size)
+	} else if evm.Config.MaxInitCodeSize != nil && size > uint64(*evm.Config.MaxInitCodeSize) {
 		return 0, fmt.Errorf("%w: size %d", ErrMaxInitCodeSizeExceeded, size)
 	}
+
 	// Since size <= params.MaxInitCodeSize, these multiplication cannot overflow
 	moreGas := params.InitCodeWordGas * ((size + 31) / 32)
 	if gas, overflow = math.SafeAdd(gas, moreGas); overflow {

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -334,9 +334,12 @@ func gasCreate2Eip3860(evm *EVM, contract *Contract, stack *Stack, mem *Memory, 
 	if overflow {
 		return 0, ErrGasUintOverflow
 	}
-	if size > params.MaxInitCodeSize {
+	if evm.Config.MaxInitCodeSize == nil && size > params.MaxInitCodeSize {
+		return 0, fmt.Errorf("%w: size %d", ErrMaxInitCodeSizeExceeded, size)
+	} else if evm.Config.MaxInitCodeSize != nil && size > uint64(*evm.Config.MaxInitCodeSize) {
 		return 0, fmt.Errorf("%w: size %d", ErrMaxInitCodeSizeExceeded, size)
 	}
+
 	// Since size <= params.MaxInitCodeSize, these multiplication cannot overflow
 	moreGas := (params.InitCodeWordGas + params.Keccak256WordGas) * ((size + 31) / 32)
 	if gas, overflow = math.SafeAdd(gas, moreGas); overflow {

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -53,6 +53,9 @@ type Config struct {
 	// MaxTxGas is the maximum gas allowed per transaction.
 	// If nil, this is interpreted as "not set" and the default params value is used.
 	MaxTxGas *uint64
+
+	MaxCodeSize     *int // Maximum code size allowed for a contract. If nil, the default params value is used.
+	MaxInitCodeSize *int // Maximum init code size allowed for a contract. If nil, the default params value is used.
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,

--- a/core/vm/tosca_integration_test.go
+++ b/core/vm/tosca_integration_test.go
@@ -1,9 +1,17 @@
 package vm
 
 import (
+	"errors"
 	"testing"
 
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
 )
 
 func TestGetInterpreter_ProducesInterpretersBasedOnConfiguration(t *testing.T) {
@@ -67,4 +75,133 @@ func TestGetInterpreter_ProducesInterpretersBasedOnConfiguration(t *testing.T) {
 			t.Errorf("unexpected interpreter, case %d -  isA: %t, isB: %t, isFresh: %t", i, A(got), B(got), Fresh(got))
 		}
 	}
+}
+
+func TestCustomCodeSize_MaxCodeSizeIsEnforcedWhenSet(t *testing.T) {
+	customLimit := 50_000
+	tests := map[string]struct {
+		maxCodeSize   *int
+		codeSize      uint64
+		expectedError error
+	}{
+		"default codeSize 0": {
+			codeSize: 0,
+		},
+		"default codeSize limit": {
+			codeSize: params.MaxCodeSize,
+		},
+		"default codeSize above limit": {
+			codeSize:      params.MaxCodeSize + 1,
+			expectedError: ErrMaxCodeSizeExceeded,
+		},
+		"custom codeSize limit": {
+			maxCodeSize: asPointer(customLimit),
+			codeSize:    uint64(customLimit),
+		},
+		"custom codeSize above limit": {
+			maxCodeSize:   asPointer(customLimit),
+			codeSize:      uint64(customLimit + 1),
+			expectedError: ErrMaxCodeSizeExceeded,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			stateDB, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+			if err != nil {
+				t.Fatalf("failed to create stateDB: %v", err)
+			}
+
+			chainConfig := &params.ChainConfig{
+				EIP158Block: big.NewInt(0),
+			}
+			blockContext := BlockContext{
+				BlockNumber: big.NewInt(10),
+				Random:      &common.Hash{0x42},
+			}
+			config := Config{
+				MaxCodeSize: test.maxCodeSize,
+			}
+			evm := NewEVM(blockContext, stateDB, chainConfig, config)
+
+			// The code to be deployed is the return of the init code,
+			// so the init code just needs to return a byte array of the specified size.
+			initCode := []byte{
+				byte(PUSH3), byte(test.codeSize >> 16), // push code size
+				byte(test.codeSize >> 8), byte(test.codeSize), // push code size
+				byte(PUSH1), 0x00, // push memory offset
+				byte(RETURN), // return
+			}
+
+			address := common.Address{1}
+			contract := NewContract(common.Address{2}, address, uint256.NewInt(0), 20_000_000, nil)
+			contract.SetCallCode(common.Hash{}, initCode)
+
+			ret, err := evm.initNewContract(contract, address)
+			if !errors.Is(err, test.expectedError) {
+				t.Errorf("unexpected error: got %v, want %v", err, test.expectedError)
+			}
+			if err == nil && len(ret) != int(test.codeSize) {
+				t.Errorf("unexpected code length: got %d, want %d", len(ret), test.codeSize)
+			}
+		})
+	}
+}
+
+func TestCustomCodeSize_GasCreateEip3860AllowsCustomMaxInitCodeSize(t *testing.T) {
+	customLimit := 100_000
+	tests := map[string]struct {
+		maxInitCodeSize *int
+		initCodeSize    uint64
+		expectedError   error
+	}{
+		"default initCodeSize limit": {
+			initCodeSize: params.MaxInitCodeSize,
+		},
+		"default initCodeSize above limit": {
+			initCodeSize:  params.MaxInitCodeSize + 1,
+			expectedError: ErrMaxInitCodeSizeExceeded,
+		},
+		"custom initCodeSize limit": {
+			maxInitCodeSize: asPointer(customLimit),
+			initCodeSize:    uint64(customLimit),
+		},
+		"custom initCodeSize above limit": {
+			maxInitCodeSize: asPointer(customLimit),
+			initCodeSize:    uint64(customLimit + 1),
+			expectedError:   ErrMaxInitCodeSizeExceeded,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			stateDB, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+			if err != nil {
+				t.Fatalf("failed to create stateDB: %v", err)
+			}
+			config := Config{
+				MaxInitCodeSize: test.maxInitCodeSize,
+			}
+			evm := NewEVM(BlockContext{}, stateDB, &params.ChainConfig{}, config)
+
+			stack := newstack()
+			stack.Push(uint256.NewInt(test.initCodeSize))
+			stack.Push(uint256.NewInt(test.initCodeSize))
+			stack.Push(uint256.NewInt(test.initCodeSize))
+
+			_, err = gasCreateEip3860(evm, nil, stack, NewMemory(), 0)
+			if !errors.Is(err, test.expectedError) {
+				t.Errorf("unexpected error: got %v, want %v", err, test.expectedError)
+			}
+
+			_, err = gasCreate2Eip3860(evm, nil, stack, NewMemory(), 0)
+			if !errors.Is(err, test.expectedError) {
+				t.Errorf("unexpected error: got %v, want %v", err, test.expectedError)
+			}
+		})
+	}
+}
+
+func asPointer[T any](v T) *T {
+	return &v
 }


### PR DESCRIPTION
This PR adds functionality to set custom limits for the maximal contract and init code size. If no values are set, the default values from ethereum are used.