### PR TITLE
Core: Fix custom code size limits

### DIFF
--- a/cmd/evm/internal/t8ntool/transaction.go
+++ b/cmd/evm/internal/t8ntool/transaction.go
@@ -180,7 +180,7 @@ func Transaction(ctx *cli.Context) error {
 		}
 		// Check whether the init code size has been exceeded.
 		if tx.To() == nil {
-			if err := vm.CheckMaxInitCodeSize(&rules, uint64(len(tx.Data()))); err != nil {
+			if err := vm.CheckMaxInitCodeSize(&rules, uint64(len(tx.Data())), nil); err != nil {
 				r.Error = err
 			}
 		}

--- a/core/sonic_changes_test.go
+++ b/core/sonic_changes_test.go
@@ -29,7 +29,7 @@ func TestCustomCodeSize_MaxInitCodeSizeIsEnforcedWhenSet(t *testing.T) {
 		},
 		"default initCodeSize above limit": {
 			initCodeSize:  params.MaxInitCodeSize + 1,
-			expectedError: ErrMaxInitCodeSizeExceeded,
+			expectedError: vm.ErrMaxInitCodeSizeExceeded,
 		},
 		"custom initCodeSize limit": {
 			maxInitCodeSize: asPointer(customLimit),
@@ -38,7 +38,7 @@ func TestCustomCodeSize_MaxInitCodeSizeIsEnforcedWhenSet(t *testing.T) {
 		"custom initCodeSize above limit": {
 			maxInitCodeSize: asPointer(customLimit),
 			initCodeSize:    uint64(customLimit + 1),
-			expectedError:   ErrMaxInitCodeSizeExceeded,
+			expectedError:   vm.ErrMaxInitCodeSizeExceeded,
 		},
 	}
 
@@ -55,7 +55,7 @@ func TestCustomCodeSize_MaxInitCodeSizeIsEnforcedWhenSet(t *testing.T) {
 			}
 			blockContext := vm.BlockContext{
 				CanTransfer: func(vm.StateDB, common.Address, *uint256.Int) bool { return true },
-				Transfer:    func(vm.StateDB, common.Address, common.Address, *uint256.Int) {},
+				Transfer:    func(vm.StateDB, common.Address, common.Address, *uint256.Int, *params.Rules) {},
 				BlockNumber: big.NewInt(10),
 				BaseFee:     big.NewInt(0),
 				Random:      &common.Hash{0x42},
@@ -78,8 +78,7 @@ func TestCustomCodeSize_MaxInitCodeSizeIsEnforcedWhenSet(t *testing.T) {
 				SkipTransactionChecks: true,
 			}
 
-			gasPool := new(GasPool)
-			gasPool.AddGas(1_000_000)
+			gasPool := NewGasPool(1_000_000)
 
 			stateTransition := newStateTransition(evm, message, gasPool)
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -508,7 +508,7 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 
 	// Check whether the init code size has been exceeded.
 	if contractCreation {
-		if err := vm.CheckMaxInitCodeSize(&rules, uint64(len(msg.Data))); err != nil {
+		if err := vm.CheckMaxInitCodeSize(&rules, uint64(len(msg.Data)), st.evm.Config.MaxInitCodeSize); err != nil {
 			return nil, err
 		}
 	}

--- a/core/state_transition_test.go
+++ b/core/state_transition_test.go
@@ -167,7 +167,7 @@ func runTestTransactionAndGetBalance(
 ) (*ExecutionResult, *uint256.Int, error) {
 	evm := vm.NewEVM(
 		vm.BlockContext{
-			Transfer:    func(vm.StateDB, common.Address, common.Address, *uint256.Int) {},
+			Transfer:    func(vm.StateDB, common.Address, common.Address, *uint256.Int, *params.Rules) {},
 			CanTransfer: func(vm.StateDB, common.Address, *uint256.Int) bool { return true },
 			Coinbase:    testCoinbase,
 		},
@@ -194,8 +194,7 @@ func runTestTransactionAndGetBalance(
 		msg.Value = big.NewInt(0)
 	}
 
-	pool := new(GasPool)
-	pool.AddGas(100_000)
+	pool := NewGasPool(100_000)
 
 	result, err := ApplyMessage(evm, msg, pool)
 	return result, evm.StateDB.GetBalance(address), err

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -88,7 +88,7 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	}
 	// Check whether the init code size has been exceeded
 	if tx.To() == nil {
-		if err := vm.CheckMaxInitCodeSize(&rules, uint64(len(tx.Data()))); err != nil {
+		if err := vm.CheckMaxInitCodeSize(&rules, uint64(len(tx.Data())), nil); err != nil {
 			return err
 		}
 	}

--- a/core/vm/common.go
+++ b/core/vm/common.go
@@ -26,8 +26,12 @@ import (
 )
 
 // CheckMaxInitCodeSize checks the size of contract initcode against the protocol-defined limit.
-func CheckMaxInitCodeSize(rules *params.Rules, size uint64) error {
-	if rules.IsAmsterdam {
+func CheckMaxInitCodeSize(rules *params.Rules, size uint64, sonicMaxInitCodeSize *int) error {
+	if sonicMaxInitCodeSize != nil {
+		if size > uint64(*sonicMaxInitCodeSize) {
+			return fmt.Errorf("%w: init code size %v limit %v", ErrMaxInitCodeSizeExceeded, size, *sonicMaxInitCodeSize)
+		}
+	} else if rules.IsAmsterdam {
 		if size > params.MaxInitCodeSizeAmsterdam {
 			return fmt.Errorf("%w: code size %v limit %v", ErrMaxInitCodeSizeExceeded, size, params.MaxInitCodeSizeAmsterdam)
 		}
@@ -41,8 +45,12 @@ func CheckMaxInitCodeSize(rules *params.Rules, size uint64) error {
 }
 
 // CheckMaxCodeSize checks the size of contract code against the protocol-defined limit.
-func CheckMaxCodeSize(rules *params.Rules, size uint64) error {
-	if rules.IsAmsterdam {
+func CheckMaxCodeSize(rules *params.Rules, size uint64, sonicMaxCodeSize *int) error {
+	if sonicMaxCodeSize != nil {
+		if size > uint64(*sonicMaxCodeSize) {
+			return fmt.Errorf("%w: code size %v limit %v", ErrMaxCodeSizeExceeded, size, *sonicMaxCodeSize)
+		}
+	} else if rules.IsAmsterdam {
 		if size > params.MaxCodeSizeAmsterdam {
 			return fmt.Errorf("%w: code size %v limit %v", ErrMaxCodeSizeExceeded, size, params.MaxCodeSizeAmsterdam)
 		}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -625,7 +625,7 @@ func (evm *EVM) initNewContract(contract *Contract, address common.Address) ([]b
 	}
 
 	// Check whether the max code size has been exceeded, assign err if the case.
-	if err := CheckMaxCodeSize(&evm.chainRules, uint64(len(ret))); err != nil {
+	if err := CheckMaxCodeSize(&evm.chainRules, uint64(len(ret)), evm.Config.MaxCodeSize); err != nil {
 		return ret, err
 	}
 

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -317,7 +317,7 @@ func gasCreateEip3860(evm *EVM, contract *Contract, stack *Stack, mem *Memory, m
 	if overflow {
 		return 0, ErrGasUintOverflow
 	}
-	if err := CheckMaxInitCodeSize(&evm.chainRules, size); err != nil {
+	if err := CheckMaxInitCodeSize(&evm.chainRules, size, evm.Config.MaxInitCodeSize); err != nil {
 		return 0, err
 	}
 	// Since size <= the protocol-defined maximum initcode size limit, these multiplication cannot overflow
@@ -336,7 +336,7 @@ func gasCreate2Eip3860(evm *EVM, contract *Contract, stack *Stack, mem *Memory, 
 	if overflow {
 		return 0, ErrGasUintOverflow
 	}
-	if err := CheckMaxInitCodeSize(&evm.chainRules, size); err != nil {
+	if err := CheckMaxInitCodeSize(&evm.chainRules, size, evm.Config.MaxInitCodeSize); err != nil {
 		return 0, err
 	}
 	// Since size <= the protocol-defined maximum initcode size limit, these multiplication cannot overflow

--- a/core/vm/tosca_integration_test.go
+++ b/core/vm/tosca_integration_test.go
@@ -182,7 +182,16 @@ func TestCustomCodeSize_GasCreateEip3860AllowsCustomMaxInitCodeSize(t *testing.T
 			config := Config{
 				MaxInitCodeSize: test.maxInitCodeSize,
 			}
-			evm := NewEVM(BlockContext{}, stateDB, &params.ChainConfig{}, config)
+			time := uint64(0)
+			chainConfig := &params.ChainConfig{
+				LondonBlock:  big.NewInt(0),
+				ShanghaiTime: &time,
+			}
+			blockContext := BlockContext{
+				BlockNumber: big.NewInt(10),
+				Random:      &common.Hash{0x42},
+			}
+			evm := NewEVM(blockContext, stateDB, chainConfig, config)
 
 			stack := newstack()
 			stack.Push(uint256.NewInt(test.initCodeSize))


### PR DESCRIPTION
Before creating branch `eth1.17.2` has been created `eth1.17.1-squshed` has been introduced to simplify the rebasing process.
There have been several conflicts due to the implementation of the new code size limits in Amsterdam. This PR adapts sonic's custom code size handling to the new implementation.