### PR TITLE
Add threadsafe storage map  to transaction

### DIFF
--- a/core/types/sonic_extensions.go
+++ b/core/types/sonic_extensions.go
@@ -1,0 +1,25 @@
+package types
+
+// SetSonicPayload stores an arbitrary value under the given key in the
+// transaction's extra payload map. The map is backed by a sync.Map, making
+// concurrent reads and writes safe without external synchronization.
+func SetSonicPayload(tx *Transaction, key string, v any) {
+	tx.extraPayload.Store(key, v)
+}
+
+// GetSonicPayload retrieves a typed value from the transaction's extra payload
+// map. It returns the value and true if the key exists and the stored value is
+// assignable to type T. If the key is missing or the value cannot be asserted
+// to T, it returns the zero value of T and false.
+func GetSonicPayload[T any](tx *Transaction, key string) (T, bool) {
+	var zero T
+	v, ok := tx.extraPayload.Load(key)
+	if !ok {
+		return zero, false
+	}
+	typed, ok := v.(T)
+	if !ok {
+		return zero, false
+	}
+	return typed, true
+}

--- a/core/types/sonic_extensions_test.go
+++ b/core/types/sonic_extensions_test.go
@@ -1,0 +1,70 @@
+package types
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestSonicPayload_IsThreadSafe(t *testing.T) {
+	tx := NewTx(&LegacyTx{})
+	var wg sync.WaitGroup
+	const keyMods = 10
+	const valueMods = 10
+
+	wg.Add(keyMods * valueMods * 2)
+	for i := range keyMods {
+		key := fmt.Sprintf("key%d", i)
+		for j := range valueMods {
+			go func() {
+				defer wg.Done()
+				SetSonicPayload(tx, key, j)
+			}()
+			go func() {
+				defer wg.Done()
+				GetSonicPayload[int](tx, key)
+			}()
+		}
+	}
+	wg.Wait()
+}
+
+func TestSonicPayload_TypedReturnsFalseIfMistyped(t *testing.T) {
+	tx := NewTx(&LegacyTx{})
+	SetSonicPayload(tx, "num", 42)
+
+	// Attempt to retrieve as a different type.
+	val, ok := GetSonicPayload[string](tx, "num")
+	if ok {
+		t.Fatal("expected ok to be false when retrieving with wrong type")
+	}
+	if val != "" {
+		t.Fatalf("expected zero value for string, got %q", val)
+	}
+}
+
+func TestSonicPayload_CanStoreMultipleKeys(t *testing.T) {
+	tx := NewTx(&LegacyTx{})
+	SetSonicPayload(tx, "a", 1)
+	SetSonicPayload(tx, "b", "hello")
+	SetSonicPayload(tx, "c", true)
+
+	if v, ok := GetSonicPayload[int](tx, "a"); !ok || v != 1 {
+		t.Fatalf("key 'a': got %v, %v", v, ok)
+	}
+	if v, ok := GetSonicPayload[string](tx, "b"); !ok || v != "hello" {
+		t.Fatalf("key 'b': got %v, %v", v, ok)
+	}
+	if v, ok := GetSonicPayload[bool](tx, "c"); !ok || v != true {
+		t.Fatalf("key 'c': got %v, %v", v, ok)
+	}
+}
+
+func TestSonicPayload_ReturnsFalseIfNotFound(t *testing.T) {
+	tx := NewTx(&LegacyTx{})
+
+	_, ok := GetSonicPayload[int](tx, "nonexistent")
+	if ok {
+		t.Fatal("expected ok to be false for unset key")
+	}
+}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -61,6 +62,10 @@ type Transaction struct {
 	hash atomic.Pointer[common.Hash]
 	size atomic.Uint64
 	from atomic.Pointer[sigCache]
+
+	// extraPayload Atomic cache for arbitrary payloads associated with the transaction,
+	// accessed via the GetSonicPayload and SetSonicPayload functions.
+	extraPayload sync.Map
 }
 
 // NewTx creates a new transaction.


### PR DESCRIPTION
This PR adds an atomic storage to the transaction type to be used by the sonic client to cache arbitrary payloads in the transaction instances. This will behave similarly as the cached sender or hash already existing in the transaction type but in a more generic manner. 